### PR TITLE
Ensure Request::$data is always an array

### DIFF
--- a/src/Mongrel2/Request.php
+++ b/src/Mongrel2/Request.php
@@ -20,7 +20,7 @@ class Request
         $this->body = $body;
 
         if ($this->headers->METHOD == 'JSON') {
-            $this->data = json_decode($body);
+            $this->data = json_decode($body, true);
         } else {
             $this->data = array();
         }
@@ -36,7 +36,7 @@ class Request
         $body = $hd[0];
 
         $headers = json_decode($headers);
-        
+
         return new Request($sender, $conn_id, $path, $headers, $body);
     }
 


### PR DESCRIPTION
This fixes the behaviour of JSON requests which were previously storing data in the request as an object (of type stdClass) rather than as an array which appeared to be the correct behaviour.
